### PR TITLE
Update helper.php - remove last 'start' in breadcrump / youarehere

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -53,7 +53,9 @@ class helper_plugin_pagetitle extends DokuWiki_Plugin {
                 }
                 $name = p_get_metadata($id, 'shorttitle', METADATA_DONT_RENDER) ?: noNS($id0);
             }
-            $items[] = '<bdi>'.$this->html_pagelink($id, $name, $exists).'</bdi>';
+            if ($i < $depth-1 OR ($i == $depth-1 AND !preg_match('/.*:'.$conf['start'].'$/', $id))) {
+                $items[] = '<bdi>'.$this->html_pagelink($id, $name, $exists).'</bdi>';
+            }
         }
         // join items with a separator
         $out = implode(' ›&#x00A0;', $items);


### PR DESCRIPTION
This pull requests modifies the output of the youarehere-function.

Normally the breadcrump look like this:
`wiki > 1st-level > 2nd-level > 3rd-level > start`

when you are using this wonderful Plugin and put in every page a ShortTitle Syntax, the breadcrumps are replaced with this ShortTitle.

The path then will be as follow: 
`wiki > 1st-Level Overview > 2nd-Level Overview > 3rd-Level Overview > 3rd-Level Overview`

The last two parts (3rd-level + start) will be replaced by the same ShortTitle, because this is only one page (3rd-level/start.txt).

This behavior is confusing the end user and does not look nice.

A simple if condition solves this, so the last "start" will be removed and the output of the replacement looks fine.

It would be great if this could get shortly in the official code :)
Background information:
I completely restructure our company wiki and would like to put a youarehere path in every page for a user friendly navigation.
It would be great if i can take advantage of your Plugin.

thanks